### PR TITLE
Layout API overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 **/*.rs.bk
 Cargo.lock
+**/flamegraph.svg
+**/perf.data

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ required-features = ["reclutch/skia"]
 
 [dev-dependencies]
 glutin = "0.22.0-alpha5"
+
+[patch.'https://github.com/jazzfool/reclutch']
+reclutch = { git = "https://github.com/zserik/reclutch", branch = "bidir-evq" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,3 @@ required-features = ["reclutch/skia"]
 
 [dev-dependencies]
 glutin = "0.22.0-alpha5"
-
-[patch.'https://github.com/jazzfool/reclutch']
-reclutch = { git = "https://github.com/zserik/reclutch", branch = "bidir-evq" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "reui"
 version = "0.0.0"
 authors = ["jazzfool <saveuselon@gmail.com>"]
 edition = "2018"
-license = "MIT / Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 bitflags = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 bitflags = "1.2"
-delegate = "0.3"
 indexmap = "1.3"
 reclutch = { git = "https://github.com/jazzfool/reclutch" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,10 @@ edition = "2018"
 license = "MIT / Apache-2.0"
 
 [dependencies]
-reclutch = { git = "https://github.com/jazzfool/reclutch" }
 bitflags = "1.2"
+delegate = "0.3"
 indexmap = "1.3"
+reclutch = { git = "https://github.com/jazzfool/reclutch" }
 
 [[example]]
 name = "showcase"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ You can still `derive` this `WidgetChildren` like so:
 struct MyWidget;
 ```
 
+### Layout
+Layout is simple and idiomatic with the provided macros:
+```rust
+let v_stack_data = VStackData::default().align(Align::Middle);
+
+define_layout! {
+    for v_stack => {
+        v_stack_data => button,
+        v_stack_data => define_layout! {
+            for another_v_stack => {
+                v_stack_data => nested_button
+            }
+        }
+    }
+}
+```
+
 ---
 
 ### You can see a rundown of all the widgets [here](Widgets.md).

--- a/Widgets.md
+++ b/Widgets.md
@@ -13,10 +13,10 @@ This is a rundown of all the widgets, giving a brief overview of each widget.
 - **`Themed.....`** ✔️
 - **`Focusable..`** ✔️
 - **Outgoing Event Queues:**
-    - `on_press`: The button was pressed.
-    - `on_release`: The button was released. Complements `on_press`.
-    - `on_mouse_inside`: The cursor began or stopped overlapping the button.
-    - `on_focus`: The button gained or lost focus.
+    - `event_queue`: `ButtonEvent`
+        - `ButtonEvent::Press`: The button has been pressed/released.
+        - `ButtonEvent::MouseHover`: The cursor has entered/left the button boundaries.
+        - `ButtonEvent::Focus`: The button has gained/lost focus.
 
 ## Abstract Widgets
 

--- a/Widgets.md
+++ b/Widgets.md
@@ -15,10 +15,8 @@ This is a rundown of all the widgets, giving a brief overview of each widget.
 - **Outgoing Event Queues:**
     - `on_press`: The button was pressed.
     - `on_release`: The button was released. Complements `on_press`.
-    - `on_mouse_enter`: The cursor began overlapping the button.
-    - `on_mouse_leave`: The cursor stopped overlapping the button. Complements `on_mouse_enter`.
-    - `on_focus`: The button gained focus.
-    - `on_blur`: The button lost focus. Complements `on_focus`.
+    - `on_mouse_inside`: The cursor began or stopped overlapping the button.
+    - `on_focus`: The button gained or lost focus.
 
 ## Abstract Widgets
 

--- a/examples/showcase/main.rs
+++ b/examples/showcase/main.rs
@@ -64,8 +64,6 @@ impl base::GraphicalAuxiliary for GraphicalAux {
 #[widget_children_trait(base::WidgetChildren)]
 struct Showcase {
     #[widget_child]
-    v_stack: ui::VStack<UpdateAux, GraphicalAux>, // note the order of widgets here, layout must come first to emit before sibling receive.
-    #[widget_child]
     button_1: ui::Button<UpdateAux, GraphicalAux>,
     #[widget_child]
     button_2: ui::Button<UpdateAux, GraphicalAux>,
@@ -73,6 +71,8 @@ struct Showcase {
     button_3: ui::Button<UpdateAux, GraphicalAux>,
     #[widget_child]
     button_4: ui::Button<UpdateAux, GraphicalAux>,
+    #[widget_child]
+    v_stack: ui::VStack<UpdateAux, GraphicalAux>,
 
     command_group_pre: CommandGroup,
     command_group_post: CommandGroup,
@@ -99,7 +99,7 @@ impl Showcase {
             alignment: ui::Align::Begin,
         };
 
-        define_layouts! {
+        define_layout! {
             for v_stack => {
                 v_stack_data => &mut button_1,
                 v_stack_data.align(ui::Align::Middle) => &mut button_2,
@@ -109,11 +109,11 @@ impl Showcase {
         };
 
         Showcase {
-            v_stack,
             button_1,
             button_2,
             button_3,
             button_4,
+            v_stack,
 
             command_group_pre: CommandGroup::new(),
             command_group_post: CommandGroup::new(),

--- a/examples/showcase/main.rs
+++ b/examples/showcase/main.rs
@@ -22,6 +22,9 @@ use {
 #[macro_use]
 extern crate reclutch;
 
+#[macro_use]
+extern crate reui;
+
 struct UpdateAux {
     window_queue: RcEventQueue<base::WindowEvent>,
     cursor: Point,
@@ -83,42 +86,25 @@ impl Showcase {
         update_aux: &mut UpdateAux,
         gfx_aux: &mut GraphicalAux,
     ) -> Self {
-        let mut v_stack =
-            ui::VStack::new(Rect::new(Point::new(50.0, 50.0), Size::new(200.0, 200.0)));
-
-        let v_stack_data = ui::VStackData {
-            top_margin: 10.0,
-            bottom_margin: 0.0,
-            alignment: ui::VStackAlignment::Left,
-        };
-
         let mut button_1 = ui::simple_button("Button 1".to_string(), theme, update_aux, gfx_aux);
         let mut button_2 = ui::simple_button("Button 2".to_string(), theme, update_aux, gfx_aux);
         let mut button_3 = ui::simple_button("Button 3".to_string(), theme, update_aux, gfx_aux);
         let mut button_4 = ui::simple_button("VStacks!".to_string(), theme, update_aux, gfx_aux);
 
-        v_stack.push(v_stack_data, &mut button_1);
-        v_stack.push(
-            ui::VStackData {
-                alignment: ui::VStackAlignment::Middle,
-                ..v_stack_data
-            },
-            &mut button_2,
-        );
-        v_stack.push(
-            ui::VStackData {
-                alignment: ui::VStackAlignment::Right,
-                ..v_stack_data
-            },
-            &mut button_3,
-        );
-        v_stack.push(
-            ui::VStackData {
-                alignment: ui::VStackAlignment::Stretch,
-                ..v_stack_data
-            },
-            &mut button_4,
-        );
+        let v_stack_data = ui::VStackData {
+            top_margin: 10.0,
+            bottom_margin: 0.0,
+            alignment: ui::Align::Begin,
+        };
+
+        let v_stack = vstack! {
+            rect: Rect::new(Point::new(50.0, 50.0), Size::new(200.0, 200.0)),
+
+            v_stack_data => button_1,
+            v_stack_data.align(ui::Align::Middle) => button_2,
+            v_stack_data.align(ui::Align::End) => button_3,
+            v_stack_data.align(ui::Align::Stretch) => button_4
+        };
 
         Showcase {
             v_stack,

--- a/examples/showcase/main.rs
+++ b/examples/showcase/main.rs
@@ -8,9 +8,8 @@ use {
         prelude::*,
         reclutch::{
             display::{
-                self, Color, CommandGroup, DisplayCommand, DisplayText, FontInfo, GraphicsDisplay,
-                Point, Rect, ResourceData, ResourceDescriptor, ResourceReference, SharedData, Size,
-                Vector,
+                self, Color, CommandGroup, DisplayCommand, FontInfo, GraphicsDisplay, Point, Rect,
+                ResourceData, ResourceDescriptor, ResourceReference, SharedData, Size, Vector,
             },
             event::RcEventQueue,
             prelude::*,
@@ -58,22 +57,20 @@ impl base::GraphicalAuxiliary for GraphicalAux {
     }
 }
 
+type ShowCaseLayedOutButton =
+    base::LayedOut<ui::Button<UpdateAux, GraphicalAux>, ui::VStack<UpdateAux, GraphicalAux>>;
+
 #[derive(WidgetChildren)]
 #[widget_children_trait(base::WidgetChildren)]
 struct Showcase {
     #[widget_child]
-    button_1:
-        base::LayedOut<ui::Button<UpdateAux, GraphicalAux>, ui::VStack<UpdateAux, GraphicalAux>>,
-    // er, this could be a little less ugly probably somehow maybe...
+    button_1: ShowCaseLayedOutButton,
     #[widget_child]
-    button_2:
-        base::LayedOut<ui::Button<UpdateAux, GraphicalAux>, ui::VStack<UpdateAux, GraphicalAux>>,
+    button_2: ShowCaseLayedOutButton,
     #[widget_child]
-    button_3:
-        base::LayedOut<ui::Button<UpdateAux, GraphicalAux>, ui::VStack<UpdateAux, GraphicalAux>>,
+    button_3: ShowCaseLayedOutButton,
     #[widget_child]
-    button_4:
-        base::LayedOut<ui::Button<UpdateAux, GraphicalAux>, ui::VStack<UpdateAux, GraphicalAux>>,
+    button_4: ShowCaseLayedOutButton,
     #[widget_child]
     v_stack: ui::VStack<UpdateAux, GraphicalAux>,
 

--- a/examples/showcase/main.rs
+++ b/examples/showcase/main.rs
@@ -86,7 +86,8 @@ impl Showcase {
         update_aux: &mut UpdateAux,
         gfx_aux: &mut GraphicalAux,
     ) -> Self {
-        let mut v_stack = ui::VStack::new(Rect::new(Point::new(50.0, 50.0), Size::new(200.0, 200.0)));
+        let mut v_stack =
+            ui::VStack::new(Rect::new(Point::new(50.0, 50.0), Size::new(200.0, 200.0)));
         let mut button_1 = ui::simple_button("Button 1".to_string(), theme, update_aux, gfx_aux);
         let mut button_2 = ui::simple_button("Button 2".to_string(), theme, update_aux, gfx_aux);
         let mut button_3 = ui::simple_button("Button 3".to_string(), theme, update_aux, gfx_aux);
@@ -100,10 +101,10 @@ impl Showcase {
 
         define_layouts! {
             for v_stack => {
-                v_stack_data => button_1,
-                v_stack_data.align(ui::Align::Middle) => button_2,
-                v_stack_data.align(ui::Align::End) => button_3,
-                v_stack_data.align(ui::Align::Stretch) => button_4
+                v_stack_data => &mut button_1,
+                v_stack_data.align(ui::Align::Middle) => &mut button_2,
+                v_stack_data.align(ui::Align::End) => &mut button_3,
+                v_stack_data.align(ui::Align::Stretch) => &mut button_4
             }
         };
 

--- a/examples/showcase/main.rs
+++ b/examples/showcase/main.rs
@@ -86,6 +86,7 @@ impl Showcase {
         update_aux: &mut UpdateAux,
         gfx_aux: &mut GraphicalAux,
     ) -> Self {
+        let mut v_stack = ui::VStack::new(Rect::new(Point::new(50.0, 50.0), Size::new(200.0, 200.0)));
         let mut button_1 = ui::simple_button("Button 1".to_string(), theme, update_aux, gfx_aux);
         let mut button_2 = ui::simple_button("Button 2".to_string(), theme, update_aux, gfx_aux);
         let mut button_3 = ui::simple_button("Button 3".to_string(), theme, update_aux, gfx_aux);
@@ -97,13 +98,13 @@ impl Showcase {
             alignment: ui::Align::Begin,
         };
 
-        let v_stack = vstack! {
-            rect: Rect::new(Point::new(50.0, 50.0), Size::new(200.0, 200.0)),
-
-            v_stack_data => button_1,
-            v_stack_data.align(ui::Align::Middle) => button_2,
-            v_stack_data.align(ui::Align::End) => button_3,
-            v_stack_data.align(ui::Align::Stretch) => button_4
+        define_layouts! {
+            for v_stack => {
+                v_stack_data => button_1,
+                v_stack_data.align(ui::Align::Middle) => button_2,
+                v_stack_data.align(ui::Align::End) => button_3,
+                v_stack_data.align(ui::Align::Stretch) => button_4
+            }
         };
 
         Showcase {

--- a/examples/showcase/main.rs
+++ b/examples/showcase/main.rs
@@ -57,22 +57,19 @@ impl base::GraphicalAuxiliary for GraphicalAux {
     }
 }
 
-type ShowCaseLayedOutButton =
-    base::LayedOut<ui::Button<UpdateAux, GraphicalAux>, ui::VStack<UpdateAux, GraphicalAux>>;
-
 #[derive(WidgetChildren)]
 #[widget_children_trait(base::WidgetChildren)]
 struct Showcase {
     #[widget_child]
-    button_1: ShowCaseLayedOutButton,
+    v_stack: ui::VStack<UpdateAux, GraphicalAux>, // note the order of widgets here, layout must come first to emit before sibling receive.
     #[widget_child]
-    button_2: ShowCaseLayedOutButton,
+    button_1: ui::Button<UpdateAux, GraphicalAux>,
     #[widget_child]
-    button_3: ShowCaseLayedOutButton,
+    button_2: ui::Button<UpdateAux, GraphicalAux>,
     #[widget_child]
-    button_4: ShowCaseLayedOutButton,
+    button_3: ui::Button<UpdateAux, GraphicalAux>,
     #[widget_child]
-    v_stack: ui::VStack<UpdateAux, GraphicalAux>,
+    button_4: ui::Button<UpdateAux, GraphicalAux>,
 
     command_group_pre: CommandGroup,
     command_group_post: CommandGroup,
@@ -95,38 +92,40 @@ impl Showcase {
             alignment: ui::VStackAlignment::Left,
         };
 
-        let button_1 = v_stack.push(
-            v_stack_data,
-            ui::simple_button("Button 1".to_string(), theme, update_aux, gfx_aux),
-        );
-        let button_2 = v_stack.push(
+        let mut button_1 = ui::simple_button("Button 1".to_string(), theme, update_aux, gfx_aux);
+        let mut button_2 = ui::simple_button("Button 2".to_string(), theme, update_aux, gfx_aux);
+        let mut button_3 = ui::simple_button("Button 3".to_string(), theme, update_aux, gfx_aux);
+        let mut button_4 = ui::simple_button("VStacks!".to_string(), theme, update_aux, gfx_aux);
+
+        v_stack.push(v_stack_data, &mut button_1);
+        v_stack.push(
             ui::VStackData {
                 alignment: ui::VStackAlignment::Middle,
                 ..v_stack_data
             },
-            ui::simple_button("Button 2".to_string(), theme, update_aux, gfx_aux),
+            &mut button_2,
         );
-        let button_3 = v_stack.push(
+        v_stack.push(
             ui::VStackData {
                 alignment: ui::VStackAlignment::Right,
                 ..v_stack_data
             },
-            ui::simple_button("Button 3".to_string(), theme, update_aux, gfx_aux),
+            &mut button_3,
         );
-        let button_4 = v_stack.push(
+        v_stack.push(
             ui::VStackData {
                 alignment: ui::VStackAlignment::Stretch,
                 ..v_stack_data
             },
-            ui::simple_button("VStacks!".to_string(), theme, update_aux, gfx_aux),
+            &mut button_4,
         );
 
         Showcase {
+            v_stack,
             button_1,
             button_2,
             button_3,
             button_4,
-            v_stack,
 
             command_group_pre: CommandGroup::new(),
             command_group_post: CommandGroup::new(),
@@ -143,13 +142,6 @@ impl Widget for Showcase {
 
     fn update(&mut self, aux: &mut UpdateAux) {
         base::invoke_update(self, aux);
-
-        self.v_stack.update_layout(vec![
-            &mut self.button_1,
-            &mut self.button_2,
-            &mut self.button_3,
-            &mut self.button_4,
-        ]);
     }
 
     fn draw(&mut self, display: &mut dyn GraphicsDisplay, aux: &mut GraphicalAux) {

--- a/examples/showcase/main.rs
+++ b/examples/showcase/main.rs
@@ -145,10 +145,10 @@ impl Widget for Showcase {
         base::invoke_update(self, aux);
 
         self.v_stack.update_layout(vec![
-            self.button_1.activate(),
-            self.button_2.activate(),
-            self.button_3.activate(),
-            self.button_4.activate(),
+            &mut self.button_1,
+            &mut self.button_2,
+            &mut self.button_3,
+            &mut self.button_4,
         ]);
     }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -214,6 +214,7 @@ pub trait Layout: WidgetChildren + Rectangular + Sized {
         data: Self::PushData,
         child: T,
     ) -> LayedOut<T, Self>;
+
     /// De-registers a widget from the layout and returns the original widget, stripped of additional data.
     ///
     /// If `restore_original` is `true`, then the original `Rect` (when the widget was `push`ed) will be restored.
@@ -222,6 +223,7 @@ pub trait Layout: WidgetChildren + Rectangular + Sized {
         child: LayedOut<T, Self>,
         restore_original: bool,
     ) -> T;
+
     /// Updates the layout of a list of children.
     fn update_layout(
         &mut self,
@@ -280,30 +282,25 @@ impl<T: WidgetChildren + Rectangular, L: Layout> Widget for LayedOut<T, L> {
     type GraphicalAux = T::GraphicalAux;
     type DisplayObject = T::DisplayObject;
 
-    fn bounds(&self) -> Rect {
-        self.widget.bounds()
-    }
-
-    fn update(&mut self, aux: &mut T::UpdateAux) {
-        self.widget.update(aux)
-    }
-
-    fn draw(
-        &mut self,
-        display: &mut dyn GraphicsDisplay<T::DisplayObject>,
-        aux: &mut T::GraphicalAux,
-    ) {
-        self.widget.draw(display, aux)
+    delegate! {
+        target self.widget {
+            fn bounds(&self) -> Rect;
+            fn update(&mut self, aux: &mut T::UpdateAux);
+            fn draw(
+                &mut self,
+                display: &mut dyn GraphicsDisplay<T::DisplayObject>,
+                aux: &mut T::GraphicalAux,
+            );
+        }
     }
 }
 
 impl<T: WidgetChildren + Rectangular, L: Layout> draw::HasTheme for LayedOut<T, L> {
-    fn theme(&mut self) -> &mut dyn draw::Themed {
-        self.widget.theme()
-    }
-
-    fn resize_from_theme(&mut self, aux: &dyn GraphicalAuxiliary) {
-        self.widget.resize_from_theme(aux)
+    delegate! {
+        target self.widget {
+            fn theme(&mut self) -> &mut dyn draw::Themed;
+            fn resize_from_theme(&mut self, aux: &dyn GraphicalAuxiliary);
+        }
     }
 }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -272,8 +272,8 @@ impl<T: LayableWidget, L: Layout> LayedOut<T, L> {
     ///
     /// Required for `update_layout`.
     #[inline(always)]
-    pub fn activate(&mut self) -> &mut dyn LayedOutTrait<U, G, D, L: Layout> {
-        &mut self
+    pub fn activate(&mut self) -> &mut dyn LayedOutTrait<T::UpdateAux, T::GraphicalAux, T::DisplayObject, L> {
+        self
     }
 }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -227,17 +227,20 @@ pub trait Layout: WidgetChildren + Rectangular + Sized {
 /// A widget with extra attached information required for a layout.
 #[derive(WidgetChildren)]
 #[widget_children_trait(WidgetChildren)]
-pub struct LayedOut<T: WidgetChildren + Rectangular, L: Layout>(T, L::ChildData);
+pub struct LayedOut<T: WidgetChildren + Rectangular, L: Layout> {
+    widget: T,
+    data: L::ChildData,
+}
 
 impl<T: WidgetChildren + Rectangular, L: Layout> LayedOut<T, L> {
     /// Creates a new `LayedOut`.
     pub fn new(widget: T, data: L::ChildData) -> Self {
-        LayedOut(widget, data)
+        LayedOut { widget, data }
     }
 
     /// Returns `self` as a tuple.
     pub fn decompose(self) -> (T, L::ChildData) {
-        (self.0, self.1)
+        (self.widget, self.data)
     }
 
     /// Dynamically and mutably borrows the inner widget and layout data.
@@ -247,19 +250,19 @@ impl<T: WidgetChildren + Rectangular, L: Layout> LayedOut<T, L> {
         &mut self,
     ) -> ActivelyLayedOut<'_, T::UpdateAux, T::GraphicalAux, T::DisplayObject, L> {
         ActivelyLayedOut {
-            widget: &mut self.0,
-            data: &mut self.1,
+            widget: &mut self.widget,
+            data: &mut self.data,
         }
     }
 
     /// Returns the attached layout data immutably.
     pub fn data(&self) -> &L::ChildData {
-        &self.1
+        &self.data
     }
 
     /// Returns the attached layout data mutably.
     pub fn data_mut(&mut self) -> &mut L::ChildData {
-        &mut self.1
+        &mut self.data
     }
 }
 
@@ -267,13 +270,13 @@ impl<T: WidgetChildren + Rectangular, L: Layout> std::ops::Deref for LayedOut<T,
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.widget
     }
 }
 
 impl<T: WidgetChildren + Rectangular, L: Layout> std::ops::DerefMut for LayedOut<T, L> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        &mut self.widget
     }
 }
 
@@ -283,11 +286,11 @@ impl<T: WidgetChildren + Rectangular, L: Layout> Widget for LayedOut<T, L> {
     type DisplayObject = T::DisplayObject;
 
     fn bounds(&self) -> Rect {
-        self.0.bounds()
+        self.widget.bounds()
     }
 
     fn update(&mut self, aux: &mut T::UpdateAux) {
-        self.0.update(aux)
+        self.widget.update(aux)
     }
 
     fn draw(
@@ -295,23 +298,23 @@ impl<T: WidgetChildren + Rectangular, L: Layout> Widget for LayedOut<T, L> {
         display: &mut dyn GraphicsDisplay<T::DisplayObject>,
         aux: &mut T::GraphicalAux,
     ) {
-        self.0.draw(display, aux)
+        self.widget.draw(display, aux)
     }
 }
 
 impl<T: WidgetChildren + Rectangular, L: Layout> draw::HasTheme for LayedOut<T, L> {
     fn theme(&mut self) -> &mut dyn draw::Themed {
-        self.0.theme()
+        self.widget.theme()
     }
 
     fn resize_from_theme(&mut self, aux: &dyn GraphicalAuxiliary) {
-        self.0.resize_from_theme(aux)
+        self.widget.resize_from_theme(aux)
     }
 }
 
 impl<T: WidgetChildren + Rectangular, L: Layout> Repaintable for LayedOut<T, L> {
     fn repaint(&mut self) {
-        self.0.repaint()
+        self.widget.repaint()
     }
 }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -2,7 +2,7 @@ use {
     crate::draw,
     reclutch::{
         display::{Color, FontInfo, GraphicsDisplay, Point, Rect, ResourceReference, Size},
-        event::{RcEventQueue, bidir::Secondary as BidirEventQueueSec},
+        event::RcEventQueue,
         prelude::*,
         widget::Widget,
     },
@@ -214,7 +214,7 @@ pub enum MouseButton {
 #[derive(Debug)]
 pub struct WidgetLayoutEventsInner {
     pub id: u64,
-    pub evq: BidirEventQueueSec<Rect, Rect>,
+    pub evq: reclutch::event::bidir_single::Secondary<Rect, Rect>,
 }
 
 #[derive(Default, Debug)]
@@ -240,7 +240,9 @@ impl WidgetLayoutEvents {
     }
 
     pub fn receive(&mut self) -> Option<Rect> {
-        self.0.as_mut().and_then(|inner| inner.evq.retrieve_newest())
+        self.0
+            .as_mut()
+            .and_then(|inner| inner.evq.retrieve_newest())
     }
 }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -229,6 +229,10 @@ impl WidgetLayoutEvents {
         WidgetLayoutEvents(Some(layout))
     }
 
+    pub fn id(&self) -> Option<u64> {
+        self.0.as_ref().map(|inner| inner.id)
+    }
+
     pub fn update<'a>(&mut self, layout: impl Into<Option<WidgetLayoutEventsInner>>) {
         self.0 = layout.into();
     }
@@ -249,6 +253,7 @@ impl WidgetLayoutEvents {
 /// Widget that is capable of listening to layout events.
 pub trait LayableWidget: WidgetChildren + Rectangular {
     fn listen_to_layout(&mut self, layout: impl Into<Option<WidgetLayoutEventsInner>>);
+    fn layout_id(&self) -> Option<u64>;
 }
 
 /// Widget which emits layout events to registered widgets.

--- a/src/base.rs
+++ b/src/base.rs
@@ -326,7 +326,7 @@ pub struct ActivelyLayedOut<'a, U, G, D, L: Layout> {
 
 /// Propagates `update` for the children of a widget.
 pub fn invoke_update<U, G, D>(
-    widget: &mut impl WidgetChildren<UpdateAux = U, GraphicalAux = G, DisplayObject = D>,
+    widget: &mut dyn WidgetChildren<UpdateAux = U, GraphicalAux = G, DisplayObject = D>,
     aux: &mut U,
 ) {
     // Iterate in reverse because most visually forefront widgets should get events first.
@@ -337,7 +337,7 @@ pub fn invoke_update<U, G, D>(
 
 /// Propagates `draw` for the children of a widget.
 pub fn invoke_draw<U, G, D>(
-    widget: &mut impl WidgetChildren<UpdateAux = U, GraphicalAux = G, DisplayObject = D>,
+    widget: &mut dyn WidgetChildren<UpdateAux = U, GraphicalAux = G, DisplayObject = D>,
     display: &mut dyn GraphicsDisplay<D>,
     aux: &mut G,
 ) {

--- a/src/ui/button.rs
+++ b/src/ui/button.rs
@@ -220,6 +220,11 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> base::LayableWidget 
     fn listen_to_layout<'a>(&mut self, layout: impl Into<Option<base::WidgetLayoutEventsInner>>) {
         self.layout.update(layout);
     }
+
+    #[inline]
+    fn layout_id(&self) -> Option<u64> {
+        self.layout.id()
+    }
 }
 
 impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> Repaintable for Button<U, G> {

--- a/src/ui/button.rs
+++ b/src/ui/button.rs
@@ -105,6 +105,7 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> Widget for Button<U,
     type GraphicalAux = G;
     type DisplayObject = DisplayCommand;
 
+    #[inline]
     fn bounds(&self) -> Rect {
         self.rect
     }
@@ -215,12 +216,14 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> Widget for Button<U,
 }
 
 impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> base::LayableWidget for Button<U, G> {
+    #[inline]
     fn listen_to_layout<'a>(&mut self, layout: impl Into<Option<base::LayoutEvents<'a>>>) {
         self.layout.update(layout);
     }
 }
 
 impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> Repaintable for Button<U, G> {
+    #[inline]
     fn repaint(&mut self) {
         self.command_group.repaint();
     }
@@ -235,6 +238,7 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> base::Movable for Bu
         self.layout.notify(self.rect);
     }
 
+    #[inline]
     fn position(&self) -> Point {
         self.rect.origin
     }
@@ -247,12 +251,14 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> base::Resizable for 
         self.layout.notify(self.rect);
     }
 
+    #[inline]
     fn size(&self) -> Size {
         self.rect.size
     }
 }
 
 impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> draw::HasTheme for Button<U, G> {
+    #[inline]
     fn theme(&mut self) -> &mut dyn draw::Themed {
         &mut self.painter
     }

--- a/src/ui/button.rs
+++ b/src/ui/button.rs
@@ -217,7 +217,7 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> Widget for Button<U,
 
 impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> base::LayableWidget for Button<U, G> {
     #[inline]
-    fn listen_to_layout<'a>(&mut self, layout: impl Into<Option<base::LayoutEvents<'a>>>) {
+    fn listen_to_layout<'a>(&mut self, layout: impl Into<Option<base::WidgetLayoutEventsInner>>) {
         self.layout.update(layout);
     }
 }

--- a/src/ui/button.rs
+++ b/src/ui/button.rs
@@ -217,7 +217,7 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> Widget for Button<U,
 
 impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> base::LayableWidget for Button<U, G> {
     #[inline]
-    fn listen_to_layout<'a>(&mut self, layout: impl Into<Option<base::WidgetLayoutEventsInner>>) {
+    fn listen_to_layout(&mut self, layout: impl Into<Option<base::WidgetLayoutEventsInner>>) {
         self.layout.update(layout);
     }
 

--- a/src/ui/button.rs
+++ b/src/ui/button.rs
@@ -177,7 +177,7 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> Widget for Button<U,
                 .emit_owned(ButtonEvent::Focus(ToggledEvent::new(!was_focused, ())));
         }
 
-        for rect in self.layout.receive() {
+        if let Some(rect) = self.layout.receive() {
             self.rect = rect;
             cmd_group.repaint();
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,6 +10,33 @@ use {
     reclutch::display,
 };
 
+#[macro_export]
+macro_rules! define_layout {
+    (for $layout:expr => {$($data:expr => $target:expr),*}) => {
+        {
+            use $crate::base::Layout;
+            $(
+                $layout.push($data, &mut $target);
+            )*
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! define_layouts {
+    ($(for $layout:expr => {$($data:expr => $target:expr),*}),*) => {
+        {
+            $(
+                define_layout! {
+                    for $layout => {
+                        $($data => $target),*
+                    }
+                };
+            )*
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ToggledEvent<T> {
     Start(T),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,8 +16,9 @@ macro_rules! define_layout {
         {
             use $crate::base::Layout;
             $(
-                $layout.push($data, &mut $target);
+                $layout.push($data, $target);
             )*
+            &mut $layout
         }
     }
 }
@@ -31,7 +32,7 @@ macro_rules! define_layouts {
                     for $layout => {
                         $($data => $target),*
                     }
-                };
+                }
             )*
         }
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,6 +10,51 @@ use {
     reclutch::display,
 };
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ToggledEvent<T> {
+    Start(T),
+    Stop(T),
+}
+
+impl<T> ToggledEvent<T> {
+    pub fn new(is_start: bool, data: T) -> Self {
+        if is_start {
+            ToggledEvent::Start(data)
+        } else {
+            ToggledEvent::Stop(data)
+        }
+    }
+
+    #[inline]
+    pub fn is_start(&self) -> bool {
+        match self {
+            ToggledEvent::Start(_) => true,
+            ToggledEvent::Stop(_) => false,
+        }
+    }
+
+    #[inline]
+    pub fn data(&self) -> &T {
+        match self {
+            ToggledEvent::Start(ref x) | ToggledEvent::Stop(ref x) => x,
+        }
+    }
+
+    #[inline]
+    pub fn data_mut(&mut self) -> &mut T {
+        match self {
+            ToggledEvent::Start(ref mut x) | ToggledEvent::Stop(ref mut x) => x,
+        }
+    }
+
+    #[inline]
+    pub fn into_data(self) -> T {
+        match self {
+            ToggledEvent::Start(x) | ToggledEvent::Stop(x) => x,
+        }
+    }
+}
+
 pub fn simple_button<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary>(
     text: String,
     theme: &dyn draw::Theme,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -23,21 +23,6 @@ macro_rules! define_layout {
     }
 }
 
-#[macro_export]
-macro_rules! define_layouts {
-    ($(for $layout:expr => {$($data:expr => $target:expr),*}),*) => {
-        {
-            $(
-                define_layout! {
-                    for $layout => {
-                        $($data => $target),*
-                    }
-                }
-            )*
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ToggledEvent<T> {
     Start(T),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -55,6 +55,26 @@ impl<T> ToggledEvent<T> {
     }
 }
 
+/// How a child should be aligned within a layout.
+/// On which axis the align applies to depends on the layout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Align {
+    /// The child is aligned to the beginning of the layout.
+    Begin,
+    /// The child is centered.
+    Middle,
+    /// The child is aligned to the end of the layout.
+    End,
+    /// The child is stretched to fill the container.
+    Stretch,
+}
+
+impl Default for Align {
+    fn default() -> Self {
+        Align::Begin
+    }
+}
+
 pub fn simple_button<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary>(
     text: String,
     theme: &dyn draw::Theme,

--- a/src/ui/vstack.rs
+++ b/src/ui/vstack.rs
@@ -68,6 +68,7 @@ where
     dirty: bool,
 
     themed: draw::PhantomThemed,
+    layout: base::WidgetLayoutEvents,
 
     phantom_u: PhantomData<U>,
     phantom_g: PhantomData<G>,
@@ -82,6 +83,7 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> VStack<U, G> {
             dirty: true,
 
             themed: Default::default(),
+            layout: Default::default(),
 
             phantom_u: Default::default(),
             phantom_g: Default::default(),
@@ -140,6 +142,11 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> Widget for VStack<U,
     }
 
     fn update(&mut self, _aux: &mut U) {
+        if let Some(rect) = self.layout.receive() {
+            self.rect = rect;
+            self.dirty = true;
+        }
+
         {
             let dirty = &mut self.dirty;
             for (_, data) in &mut self.rects {
@@ -175,6 +182,18 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> Widget for VStack<U,
 
             self.dirty = false;
         }
+    }
+}
+
+impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> base::LayableWidget for VStack<U, G> {
+    #[inline]
+    fn listen_to_layout<'a>(&mut self, layout: impl Into<Option<base::WidgetLayoutEventsInner>>) {
+        self.layout.update(layout);
+    }
+
+    #[inline]
+    fn layout_id(&self) -> Option<u64> {
+        self.layout.id()
     }
 }
 

--- a/src/ui/vstack.rs
+++ b/src/ui/vstack.rs
@@ -10,19 +10,6 @@ use {
     std::marker::PhantomData,
 };
 
-#[macro_export]
-macro_rules! vstack {
-    (rect: $rect:expr,$($data:expr => $target:expr),*) => {
-        {
-            let mut vstack = $crate::ui::vstack::VStack::new($rect);
-            $(
-                vstack.push($data, &mut $target);
-            )*
-            vstack
-        }
-    }
-}
-
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub struct VStackData {
     pub top_margin: f32,

--- a/src/ui/vstack.rs
+++ b/src/ui/vstack.rs
@@ -92,8 +92,7 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> base::Layout for VSt
         _restore_original: bool,
     ) -> T {
         self.dirty = true;
-
-        child.decompose().0
+        child.widget
     }
 
     fn update_layout(

--- a/src/ui/vstack.rs
+++ b/src/ui/vstack.rs
@@ -125,9 +125,9 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> Widget for VStack<U,
             for (_, data) in &mut self.rects {
                 let rect = &mut data.rect;
                 data.input.with(|events| {
-                    for event in events {
+                    if let Some(new_ev) = events.last() {
                         *dirty = true;
-                        *rect = *event;
+                        *rect = *new_ev;
                     }
                 });
             }
@@ -164,33 +164,40 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> Widget for VStack<U,
 }
 
 impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> base::Repaintable for VStack<U, G> {
+    #[inline]
     fn repaint(&mut self) {}
 }
 
 impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> base::Movable for VStack<U, G> {
+    #[inline]
     fn set_position(&mut self, position: Point) {
         self.rect.origin = position;
     }
 
+    #[inline]
     fn position(&self) -> Point {
         self.rect.origin
     }
 }
 
 impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> base::Resizable for VStack<U, G> {
+    #[inline]
     fn set_size(&mut self, size: Size) {
         self.rect.size = size;
     }
 
+    #[inline]
     fn size(&self) -> Size {
         self.rect.size
     }
 }
 
 impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> draw::HasTheme for VStack<U, G> {
+    #[inline]
     fn theme(&mut self) -> &mut dyn draw::Themed {
         &mut self.themed
     }
 
+    #[inline]
     fn resize_from_theme(&mut self, _aux: &dyn base::GraphicalAuxiliary) {}
 }

--- a/src/ui/vstack.rs
+++ b/src/ui/vstack.rs
@@ -174,7 +174,7 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> Widget for VStack<U,
 
 impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> base::LayableWidget for VStack<U, G> {
     #[inline]
-    fn listen_to_layout<'a>(&mut self, layout: impl Into<Option<base::WidgetLayoutEventsInner>>) {
+    fn listen_to_layout(&mut self, layout: impl Into<Option<base::WidgetLayoutEventsInner>>) {
         self.layout.update(layout);
     }
 

--- a/src/ui/vstack.rs
+++ b/src/ui/vstack.rs
@@ -97,24 +97,17 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> base::Layout for VSt
 
     fn update_layout(
         &mut self,
-        children: Vec<
-            &mut dyn base::LayedOutTrait<
-                Self::UpdateAux,
-                Self::GraphicalAux,
-                Self::DisplayObject,
-                Self,
-            >,
-        >,
+        children: Vec<&mut base::LayedOutDyn<Self, Self>>,
     ) {
-        if !self.dirty
-            && !children.iter().any(|child| {
+        if !(self.dirty
+            || children.iter().any(|child| {
                 let (child_widget, child_data) = child.as_ref();
                 child_widget.rect()
                     != *self
                         .rects
                         .get(&child_data.id)
                         .expect("invalid layout child ID")
-            })
+            }))
         {
             // nothing to update
             return;

--- a/src/ui/vstack.rs
+++ b/src/ui/vstack.rs
@@ -3,7 +3,7 @@ use {
     indexmap::IndexMap,
     reclutch::{
         display::{self, DisplayCommand, Point, Rect, Size},
-        event::bidir::Queue as BidirEventQueue,
+        event::bidir_single::Queue as Bidir1EventQueue,
         prelude::*,
     },
     std::marker::PhantomData,
@@ -32,7 +32,7 @@ pub struct VStackData {
 #[derive(Debug)]
 struct ChildData {
     data: VStackData,
-    evq: BidirEventQueue<Rect, Rect>,
+    evq: Bidir1EventQueue<Rect, Rect>,
     rect: Rect,
 }
 
@@ -80,7 +80,7 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> base::Layout for VSt
         let id = self.next_rect_id;
         self.next_rect_id += 1;
 
-        let evq = BidirEventQueue::new();
+        let evq = Bidir1EventQueue::new();
 
         child.listen_to_layout(base::WidgetLayoutEventsInner {
             id,

--- a/src/ui/vstack.rs
+++ b/src/ui/vstack.rs
@@ -89,7 +89,7 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> base::Layout for VSt
     fn remove<T: base::WidgetChildren + base::Rectangular>(
         &mut self,
         child: base::LayedOut<T, Self>,
-        restore_original: bool,
+        _restore_original: bool,
     ) -> T {
         self.dirty = true;
 

--- a/src/ui/vstack.rs
+++ b/src/ui/vstack.rs
@@ -110,7 +110,7 @@ impl<U: base::UpdateAuxiliary, G: base::GraphicalAuxiliary> base::Layout for VSt
 
     /// De-registers a widget from the layout, optionally restoring the original widget rectangle.
     fn remove(&mut self, child: &mut impl base::LayableWidget, restore_original: bool) {
-        if let Some(Some(data)) = child.layout_id().map(|id| self.rects.remove(&id)) {
+        if let Some(data) = child.layout_id().and_then(|id| self.rects.remove(&id)) {
             child.listen_to_layout(None);
             if restore_original {
                 child.set_rect(data.original_rect);


### PR DESCRIPTION
I looked through the codebase and found some "places" which seemed to be improvable or suboptimal, but I'm not sure if the alternatives which I propose here are better than that.

What I've done:
* introduced additional traits and type aliases, avoid some repetition
* replaced the `ActivelyLayedOut` structure with a trait to reduce the indirection (but I kept the `activate` method to keep ergonomics when automatic coericions aren't enough)
* only call `repaint` at most once in `VStack::update_layout`
* wrap the inner data of `ConsumableEvent` inside the Rc and thus avoid cloning it
* use the `delegate` crate to reduce boilerplate (this could/should be replaced with the `ambassador` crate once it's usable on stable rust)

To consider:
* replace the `RefCell<bool>` with `AtomicBool` (may be a good idea, but unneeded bc `ConsumableEvent` isn't thread-safe as long as it uses `Rc`)
* introduce a macro to generate the vec which is passed to `update_layout` or save enough information about that in `VStack` to get rid of the argument or use all elements as default if an empty `Vec` is given. This currently looks like a violation of the `DRY` principle.